### PR TITLE
Suggestion - image cropping support. Adding podspec

### DIFF
--- a/RNColorThief.podspec
+++ b/RNColorThief.podspec
@@ -1,6 +1,6 @@
 require "json"
 
-package = JSON.parse(File.read(File.join(__dir__, "../package.json")))
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "RNColorThief"

--- a/RNColorThief.podspec
+++ b/RNColorThief.podspec
@@ -9,12 +9,12 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNColorThief
                    DESC
-  s.homepage     = "https://github.com/joinlane/react-native-color-thief"
+  s.homepage     = package["repository"]["baseUrl"]
   s.license      = "MIT"
   # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author       = { "author" => "author@domain.cn" }
+  s.author       = { "author" => package["author"]["name"] }
   s.platform     = :ios, "10.0"
-  s.source       = { :git => "https://github.com/joinlane/react-native-color-thief.git", :tag => "#{s.version}" }
+  s.source       = { :git => package["repository"]["url"], :tag => "#{s.version}" }
 
   s.source_files = "ios/*.swift", "ios/*.h", "ios/*.m"
   s.requires_arc = true

--- a/android/src/main/java/com/RNColorThief/RNColorThief.java
+++ b/android/src/main/java/com/RNColorThief/RNColorThief.java
@@ -19,207 +19,141 @@
 
 package com.RNColorThief;
 
+import java.net.URL;
+import java.io.IOException;
+
 import android.graphics.Bitmap;
-import java.util.Arrays;
+import android.graphics.BitmapFactory;
+import android.util.Base64;
 
-import com.RNColorThief.MMCQ.CMap;
+public class RNColorThief {
 
-public class ColorThief {
-
-    private static final int DEFAULT_QUALITY = 10;
-    private static final boolean DEFAULT_IGNORE_WHITE = true;
-
-    /**
-     * Use the median cut algorithm to cluster similar colors and return the base color from the
-     * largest cluster.
-     *
-     * @param sourceImage
-     *            the source image
-     *
-     * @return the dominant color as RGB array
-     */
-    public static int[] getColor(Bitmap sourceImage) {
-        int[][] palette = getPalette(sourceImage, 5);
-        if (palette == null) {
+    public static int[] getColor(String imageUrl) {
+        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl);
+        if (sourceImage == null) {
             return null;
         }
-        int[] dominantColor = palette[0];
-        return dominantColor;
+
+        return ColorThief.getColor(sourceImage);
     }
 
-    /**
-     * Use the median cut algorithm to cluster similar colors and return the base color from the
-     * largest cluster.
-     *
-     * @param sourceImage
-     *            the source image
-     * @param quality
-     *            1 is the highest quality settings. 10 is the default. There is a trade-off between
-     *            quality and speed. The bigger the number, the faster a color will be returned but
-     *            the greater the likelihood that it will not be the visually most dominant color.
-     * @param ignoreWhite
-     *            if <code>true</code>, white pixels are ignored
-     *
-     * @return the dominant color as RGB array
-     * @throws IllegalArgumentException
-     *             if quality is &lt; 1
-     */
-    public static int[] getColor(Bitmap sourceImage, int quality, boolean ignoreWhite) {
-        int[][] palette = getPalette(sourceImage, 5, quality, ignoreWhite);
-        if (palette == null) {
+    public static int[] getColor(String imageUrl, int quality, boolean ignoreWhite) {
+        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl);
+
+        if (sourceImage == null) {
             return null;
         }
-        int[] dominantColor = palette[0];
-        return dominantColor;
+
+        return ColorThief.getColor(sourceImage, quality, ignoreWhite);
     }
 
-    /**
-     * Use the median cut algorithm to cluster similar colors.
-     *
-     * @param sourceImage
-     *            the source image
-     * @param colorCount
-     *            the size of the palette; the number of colors returned
-     *
-     * @return the palette as array of RGB arrays
-     */
-    public static int[][] getPalette(Bitmap sourceImage, int colorCount) {
-        CMap cmap = getColorMap(sourceImage, colorCount);
-        if (cmap == null) {
+    public static int[] getColor(String imageUrl,
+                                 int quality,
+                                 boolean ignoreWhite,
+                                 int width,
+                                 int height) {
+        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl, width, height);
+
+        if (sourceImage == null) {
             return null;
         }
-        return cmap.palette();
+
+        return ColorThief.getColor(sourceImage, quality, ignoreWhite);
     }
 
-    /**
-     * Use the median cut algorithm to cluster similar colors.
-     *
-     * @param sourceImage
-     *            the source image
-     * @param colorCount
-     *            the size of the palette; the number of colors returned
-     * @param quality
-     *            1 is the highest quality settings. 10 is the default. There is a trade-off between
-     *            quality and speed. The bigger the number, the faster the palette generation but
-     *            the greater the likelihood that colors will be missed.
-     * @param ignoreWhite
-     *            if <code>true</code>, white pixels are ignored
-     *
-     * @return the palette as array of RGB arrays
-     * @throws IllegalArgumentException
-     *             if quality is &lt; 1
-     */
+    public static int[][] getPalette(String imageUrl, int colorCount) {
+        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl);
+        if (sourceImage == null) {
+            return null;
+        }
+
+        return ColorThief.getPalette(sourceImage, colorCount);
+    }
+
     public static int[][] getPalette(
-            Bitmap sourceImage,
+            String imageUrl,
             int colorCount,
             int quality,
             boolean ignoreWhite) {
-        CMap cmap = getColorMap(sourceImage, colorCount, quality, ignoreWhite);
-        if (cmap == null) {
+
+        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl);
+        if (sourceImage == null) {
             return null;
         }
-        return cmap.palette();
+
+        return ColorThief.getPalette(sourceImage, colorCount, quality, ignoreWhite);
     }
 
-    /**
-     * Use the median cut algorithm to cluster similar colors.
-     *
-     * @param sourceImage
-     *            the source image
-     * @param colorCount
-     *            the size of the palette; the number of colors returned (minimum 2, maximum 256)
-     *
-     * @return the color map
-     */
-    public static CMap getColorMap(Bitmap sourceImage, int colorCount) {
-        return getColorMap(sourceImage, colorCount, DEFAULT_QUALITY, DEFAULT_IGNORE_WHITE);
-    }
-
-    /**
-     * Use the median cut algorithm to cluster similar colors.
-     *
-     * @param sourceImage
-     *            the source image
-     * @param colorCount
-     *            the size of the palette; the number of colors returned (minimum 2, maximum 256)
-     * @param quality
-     *            1 is the highest quality settings. 10 is the default. There is a trade-off between
-     *            quality and speed. The bigger the number, the faster the palette generation but
-     *            the greater the likelihood that colors will be missed.
-     * @param ignoreWhite
-     *            if <code>true</code>, white pixels are ignored
-     *
-     * @return the color map
-     * @throws IllegalArgumentException
-     *             if quality is &lt; 1
-     */
-    public static CMap getColorMap(
-            Bitmap sourceImage,
+    public static int[][] getPalette(
+            String imageUrl,
             int colorCount,
             int quality,
-            boolean ignoreWhite) {
-        if (colorCount < 2 || colorCount > 256) {
-            throw new IllegalArgumentException("Specified colorCount must be between 2 and 256.");
-        }
-        if (quality < 1) {
-            throw new IllegalArgumentException("Specified quality should be greater then 0.");
+            boolean ignoreWhite,
+            int width,
+            int height) {
+
+        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl, width, height);
+
+        if (sourceImage == null) {
+            return null;
         }
 
-        int[][] pixelArray = getPixels(sourceImage, quality, ignoreWhite);
-
-        // Send array to quantize function which clusters values using median cut algorithm
-        CMap cmap = MMCQ.quantize(pixelArray, colorCount);
-        return cmap;
+        return ColorThief.getPalette(sourceImage, colorCount, quality, ignoreWhite);
     }
 
     /**
-     * Gets the image's pixels via Bitmap.getPixels(..).
+     * Retrieve image source from remote url.
      *
-     * @param sourceImage
-     *            the source image
-     * @param quality
-     *            1 is the highest quality settings. 10 is the default. There is a trade-off between
-     *            quality and speed. The bigger the number, the faster the palette generation but
-     *            the greater the likelihood that colors will be missed.
-     * @param ignoreWhite
-     *            if <code>true</code>, white pixels are ignored
-     *
-     * @return an array of pixels (each an RGB int array)
+     * @param imageUrl the image url
+     * @return the image as a Bitmap
      */
-    private static int[][] getPixels(
-            Bitmap sourceImage,
-            int quality,
-            boolean ignoreWhite) {
-        int width = sourceImage.getWidth();
-        int height = sourceImage.getHeight();
+    private static Bitmap retrieveImageFromUrl(String imageUrl) {
+        return retrieveImageFromUrl(imageUrl, 0, 0);
+    }
 
-        int pixelCount = width * height;
+    /**
+     * Retrieve image source from remote url.
+     *
+     * @param imageUrl the image url
+     * @param width    crop the image to this width
+     * @param height   crop the image to this height
+     * @return the image as a Bitmap
+     */
+    private static Bitmap retrieveImageFromUrl(String imageUrl, int width, int height) {
+        Bitmap image;
+        Bitmap croppedImage;
+        int _width;
+        int _height;
 
-        // numRegardedPixels must be rounded up to avoid an ArrayIndexOutOfBoundsException if all
-        // pixels are good.
-        int numRegardedPixels = (pixelCount + quality - 1) / quality;
+        if (imageUrl.startsWith("data:image")) {
+            String base64Image = imageUrl.split(",")[1];
 
-        int numUsedPixels = 0;
-
-        int[][] res = new int[numRegardedPixels][];
-        int r, g, b;
-
-        int[] pixels = new int[pixelCount];
-        sourceImage.getPixels(pixels, 0, width, 0, 0, width, height);
-
-        for (int i = 0; i < pixelCount; i += quality) {
-            int argb = pixels[i];
-
-            r = (argb >> 16) & 0xFF;
-            g = (argb >> 8) & 0xFF;
-            b = (argb) & 0xFF;
-            if (!(ignoreWhite && r > 250 && g > 250 && b > 250)) {
-                res[numUsedPixels] = new int[] {r, g, b};
-                numUsedPixels++;
+            byte[] decodedString = Base64.decode(base64Image, Base64.DEFAULT);
+            image = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
+        } else {
+            try {
+                URL url = new URL(imageUrl);
+                image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
+            } catch (IOException e) {
+                System.out.println(e);
+                return null;
             }
         }
 
-        return Arrays.copyOfRange(res, 0, numUsedPixels);
+        // no cropping just return the image
+        if (width == 0 && height == 0) {
+            return image;
+        }
+
+        if (width == 0) {
+            _width = image.getWidth();
+        }
+
+        if (height == 0) {
+            _height = image.getHeight();
+        }
+
+        return Bitmap.createBitmap(image, 0, 0, image.getWidth(), height);
     }
 
 }

--- a/android/src/main/java/com/RNColorThief/RNColorThief.java
+++ b/android/src/main/java/com/RNColorThief/RNColorThief.java
@@ -12,88 +12,214 @@
  * ------
  * Lokesh Dhakar - for the original Color Thief JavaScript version
  * available at http://lokeshdhakar.com/projects/color-thief/
- * 
+ *
  * Sven Woltmann - for the fast Java Implementation of Color Thief
- * available at https://github.com/SvenWoltmann/color-thief-java 
+ * available at https://github.com/SvenWoltmann/color-thief-java
  */
 
 package com.RNColorThief;
 
-import java.net.URL;
-import java.io.IOException;
-
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.util.Base64;
+import java.util.Arrays;
 
-public class RNColorThief {
+import com.RNColorThief.MMCQ.CMap;
 
-    public static int[] getColor(String imageUrl) {
-        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl);
-        if (sourceImage == null) {
+public class ColorThief {
+
+    private static final int DEFAULT_QUALITY = 10;
+    private static final boolean DEFAULT_IGNORE_WHITE = true;
+
+    /**
+     * Use the median cut algorithm to cluster similar colors and return the base color from the
+     * largest cluster.
+     *
+     * @param sourceImage
+     *            the source image
+     *
+     * @return the dominant color as RGB array
+     */
+    public static int[] getColor(Bitmap sourceImage) {
+        int[][] palette = getPalette(sourceImage, 5);
+        if (palette == null) {
             return null;
         }
-
-		return ColorThief.getColor(sourceImage);
-    }
-
-    public static int[] getColor(String imageUrl, int quality, boolean ignoreWhite) {
-        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl);
-        if (sourceImage == null) {
-            return null;
-        }
-
-		return ColorThief.getColor(sourceImage, quality, ignoreWhite);
-    }
-
-    public static int[][] getPalette(String imageUrl, int colorCount) {
-        Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl);
-        if (sourceImage == null) {
-            return null;
-        }
-
-		return ColorThief.getPalette(sourceImage, colorCount);
-    }
-
-    public static int[][] getPalette(
-			String imageUrl,
-            int colorCount,
-            int quality,
-            boolean ignoreWhite) {
-
-		Bitmap sourceImage = RNColorThief.retrieveImageFromUrl(imageUrl);
-        if (sourceImage == null) {
-            return null;
-        }
-
-		return ColorThief.getPalette(sourceImage, colorCount, quality, ignoreWhite);
+        int[] dominantColor = palette[0];
+        return dominantColor;
     }
 
     /**
-     * Retrieve image source from remote url.
+     * Use the median cut algorithm to cluster similar colors and return the base color from the
+     * largest cluster.
      *
-     * @param imageUrl
-     *          the image url
+     * @param sourceImage
+     *            the source image
+     * @param quality
+     *            1 is the highest quality settings. 10 is the default. There is a trade-off between
+     *            quality and speed. The bigger the number, the faster a color will be returned but
+     *            the greater the likelihood that it will not be the visually most dominant color.
+     * @param ignoreWhite
+     *            if <code>true</code>, white pixels are ignored
      *
-     * @return the image as a Bitmap
+     * @return the dominant color as RGB array
+     * @throws IllegalArgumentException
+     *             if quality is &lt; 1
      */
-    private static Bitmap retrieveImageFromUrl(String imageUrl) {
-        if (imageUrl.startsWith("data:image")) {
-            String base64Image = imageUrl.split(",")[1];
-
-            byte[] decodedString = Base64.decode(base64Image, Base64.DEFAULT);
-            Bitmap image = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
-            return image;
+    public static int[] getColor(Bitmap sourceImage, int quality, boolean ignoreWhite) {
+        int[][] palette = getPalette(sourceImage, 5, quality, ignoreWhite);
+        if (palette == null) {
+            return null;
         }
-        else {
-            try {
-                URL url = new URL(imageUrl);
-                Bitmap image = BitmapFactory.decodeStream(url.openConnection().getInputStream());
-                return image;
-            } catch (IOException e) {
-                System.out.println(e);
-                return null;
+        int[] dominantColor = palette[0];
+        return dominantColor;
+    }
+
+    /**
+     * Use the median cut algorithm to cluster similar colors.
+     *
+     * @param sourceImage
+     *            the source image
+     * @param colorCount
+     *            the size of the palette; the number of colors returned
+     *
+     * @return the palette as array of RGB arrays
+     */
+    public static int[][] getPalette(Bitmap sourceImage, int colorCount) {
+        CMap cmap = getColorMap(sourceImage, colorCount);
+        if (cmap == null) {
+            return null;
+        }
+        return cmap.palette();
+    }
+
+    /**
+     * Use the median cut algorithm to cluster similar colors.
+     *
+     * @param sourceImage
+     *            the source image
+     * @param colorCount
+     *            the size of the palette; the number of colors returned
+     * @param quality
+     *            1 is the highest quality settings. 10 is the default. There is a trade-off between
+     *            quality and speed. The bigger the number, the faster the palette generation but
+     *            the greater the likelihood that colors will be missed.
+     * @param ignoreWhite
+     *            if <code>true</code>, white pixels are ignored
+     *
+     * @return the palette as array of RGB arrays
+     * @throws IllegalArgumentException
+     *             if quality is &lt; 1
+     */
+    public static int[][] getPalette(
+            Bitmap sourceImage,
+            int colorCount,
+            int quality,
+            boolean ignoreWhite) {
+        CMap cmap = getColorMap(sourceImage, colorCount, quality, ignoreWhite);
+        if (cmap == null) {
+            return null;
+        }
+        return cmap.palette();
+    }
+
+    /**
+     * Use the median cut algorithm to cluster similar colors.
+     *
+     * @param sourceImage
+     *            the source image
+     * @param colorCount
+     *            the size of the palette; the number of colors returned (minimum 2, maximum 256)
+     *
+     * @return the color map
+     */
+    public static CMap getColorMap(Bitmap sourceImage, int colorCount) {
+        return getColorMap(sourceImage, colorCount, DEFAULT_QUALITY, DEFAULT_IGNORE_WHITE);
+    }
+
+    /**
+     * Use the median cut algorithm to cluster similar colors.
+     *
+     * @param sourceImage
+     *            the source image
+     * @param colorCount
+     *            the size of the palette; the number of colors returned (minimum 2, maximum 256)
+     * @param quality
+     *            1 is the highest quality settings. 10 is the default. There is a trade-off between
+     *            quality and speed. The bigger the number, the faster the palette generation but
+     *            the greater the likelihood that colors will be missed.
+     * @param ignoreWhite
+     *            if <code>true</code>, white pixels are ignored
+     *
+     * @return the color map
+     * @throws IllegalArgumentException
+     *             if quality is &lt; 1
+     */
+    public static CMap getColorMap(
+            Bitmap sourceImage,
+            int colorCount,
+            int quality,
+            boolean ignoreWhite) {
+        if (colorCount < 2 || colorCount > 256) {
+            throw new IllegalArgumentException("Specified colorCount must be between 2 and 256.");
+        }
+        if (quality < 1) {
+            throw new IllegalArgumentException("Specified quality should be greater then 0.");
+        }
+
+        int[][] pixelArray = getPixels(sourceImage, quality, ignoreWhite);
+
+        // Send array to quantize function which clusters values using median cut algorithm
+        CMap cmap = MMCQ.quantize(pixelArray, colorCount);
+        return cmap;
+    }
+
+    /**
+     * Gets the image's pixels via Bitmap.getPixels(..).
+     *
+     * @param sourceImage
+     *            the source image
+     * @param quality
+     *            1 is the highest quality settings. 10 is the default. There is a trade-off between
+     *            quality and speed. The bigger the number, the faster the palette generation but
+     *            the greater the likelihood that colors will be missed.
+     * @param ignoreWhite
+     *            if <code>true</code>, white pixels are ignored
+     *
+     * @return an array of pixels (each an RGB int array)
+     */
+    private static int[][] getPixels(
+            Bitmap sourceImage,
+            int quality,
+            boolean ignoreWhite) {
+        int width = sourceImage.getWidth();
+        int height = sourceImage.getHeight();
+
+        int pixelCount = width * height;
+
+        // numRegardedPixels must be rounded up to avoid an ArrayIndexOutOfBoundsException if all
+        // pixels are good.
+        int numRegardedPixels = (pixelCount + quality - 1) / quality;
+
+        int numUsedPixels = 0;
+
+        int[][] res = new int[numRegardedPixels][];
+        int r, g, b;
+
+        int[] pixels = new int[pixelCount];
+        sourceImage.getPixels(pixels, 0, width, 0, 0, width, height);
+
+        for (int i = 0; i < pixelCount; i += quality) {
+            int argb = pixels[i];
+
+            r = (argb >> 16) & 0xFF;
+            g = (argb >> 8) & 0xFF;
+            b = (argb) & 0xFF;
+            if (!(ignoreWhite && r > 250 && g > 250 && b > 250)) {
+                res[numUsedPixels] = new int[] {r, g, b};
+                numUsedPixels++;
             }
         }
+
+        return Arrays.copyOfRange(res, 0, numUsedPixels);
     }
+
 }

--- a/android/src/main/java/com/RNColorThief/RNColorThiefModule.java
+++ b/android/src/main/java/com/RNColorThief/RNColorThiefModule.java
@@ -8,6 +8,8 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableNativeArray;
 
 
 public class RNColorThiefModule extends ReactContextBaseJavaModule {
@@ -25,8 +27,8 @@ public class RNColorThiefModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getPalette(String imageUrl, int quality, int count, boolean ignoreWhite, Promise promise) {
-    int[][] rgb = RNColorThief.getPalette(imageUrl, quality, count, ignoreWhite);
+  public void getPalette(String imageUrl, int quality, int count, boolean ignoreWhite, int width, int height, Promise promise) {
+    int[][] rgb = RNColorThief.getPalette(imageUrl, quality, count, ignoreWhite, width, height);
 
 
     WritableArray resultArray = new WritableNativeArray();
@@ -43,8 +45,8 @@ public class RNColorThiefModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getColor(String imageUrl, int quality, boolean ignoreWhite, Promise promise) {
-    int[] rgb = RNColorThief.getColor(imageUrl, quality, ignoreWhite);
+  public void getColor(String imageUrl, int quality, boolean ignoreWhite, int width, int height, Promise promise) {
+    int[] rgb = RNColorThief.getColor(imageUrl, quality, ignoreWhite, width, height);
 
     WritableMap resultData = new WritableNativeMap();
     resultData.putInt("r", rgb[0]);

--- a/android/src/main/java/com/RNColorThief/RNColorThiefModule.java
+++ b/android/src/main/java/com/RNColorThief/RNColorThiefModule.java
@@ -26,7 +26,7 @@ public class RNColorThiefModule extends ReactContextBaseJavaModule {
     return "RNColorThief";
   }
 
-  private WriteableMap getDefaultColor() {
+  private WritableMap getDefaultColor() {
     WritableMap resultData = new WritableNativeMap();
     resultData.putInt("r", 0);
     resultData.putInt("g", 0);

--- a/android/src/main/java/com/RNColorThief/RNColorThiefModule.java
+++ b/android/src/main/java/com/RNColorThief/RNColorThiefModule.java
@@ -26,33 +26,51 @@ public class RNColorThiefModule extends ReactContextBaseJavaModule {
     return "RNColorThief";
   }
 
+  private WriteableMap getDefaultColor() {
+    WritableMap resultData = new WritableNativeMap();
+    resultData.putInt("r", 0);
+    resultData.putInt("g", 0);
+    resultData.putInt("b", 0);
+    return resultData;
+  }
+
   @ReactMethod
   public void getPalette(String imageUrl, int quality, int count, boolean ignoreWhite, int width, int height, Promise promise) {
-    int[][] rgb = RNColorThief.getPalette(imageUrl, quality, count, ignoreWhite, width, height);
+    try {
+      int[][] rgb = RNColorThief.getPalette(imageUrl, quality, count, ignoreWhite, width, height);
 
 
-    WritableArray resultArray = new WritableNativeArray();
+      WritableArray resultArray = new WritableNativeArray();
 
-    for (int i=0; i<rgb.length; i++) {
-      WritableMap resultData = new WritableNativeMap();
-      resultData.putInt("r", rgb[i][0]);
-      resultData.putInt("g", rgb[i][1]);
-      resultData.putInt("b", rgb[i][2]);
-      resultArray.pushMap(resultData);
+      for (int i = 0; i < rgb.length; i++) {
+        WritableMap resultData = new WritableNativeMap();
+        resultData.putInt("r", rgb[i][0]);
+        resultData.putInt("g", rgb[i][1]);
+        resultData.putInt("b", rgb[i][2]);
+        resultArray.pushMap(resultData);
+      }
+
+      promise.resolve(resultArray);
+    } catch (Exception ex) {
+      WritableArray resultArray = new WritableNativeArray();
+      resultArray.pushMap(getDefaultColor());
+      promise.resolve(resultArray);
     }
-
-    promise.resolve(resultArray);
   }
 
   @ReactMethod
   public void getColor(String imageUrl, int quality, boolean ignoreWhite, int width, int height, Promise promise) {
-    int[] rgb = RNColorThief.getColor(imageUrl, quality, ignoreWhite, width, height);
+    try {
+      int[] rgb = RNColorThief.getColor(imageUrl, quality, ignoreWhite, width, height);
 
-    WritableMap resultData = new WritableNativeMap();
-    resultData.putInt("r", rgb[0]);
-    resultData.putInt("g", rgb[1]);
-    resultData.putInt("b", rgb[2]);
+      WritableMap resultData = new WritableNativeMap();
+      resultData.putInt("r", rgb[0]);
+      resultData.putInt("g", rgb[1]);
+      resultData.putInt("b", rgb[2]);
 
-    promise.resolve(resultData);
+      promise.resolve(resultData);
+    } catch (Exception e) {
+      promise.resolve(getDefaultColor());
+    }
   }
 }

--- a/ios/RNColorThief.m
+++ b/ios/RNColorThief.m
@@ -7,8 +7,8 @@
 
 @interface RCT_EXTERN_MODULE(RNColorThief, NSObject)
 
-RCT_EXTERN_METHOD(getColor: (NSString*)source quality: (int)quality ignoreWhite: (BOOL)ignoreWhite resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getColor: (NSString*)source quality: (int)quality ignoreWhite: (BOOL)ignoreWhite width: (int)width height: (int)height resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getPalette: (NSString*)source colorCount: (int)colorCount quality: (int)quality ignoreWhite: (BOOL)ignoreWhite resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getPalette: (NSString*)source colorCount: (int)colorCount quality: (int)quality ignoreWhite:  width: (int)width height: (int)height  (BOOL)ignoreWhite resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ios/RNColorThief.podspec
+++ b/ios/RNColorThief.podspec
@@ -1,0 +1,24 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "RNColorThief"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.description  = <<-DESC
+                  RNColorThief
+                   DESC
+  s.homepage     = "https://github.com/joinlane/react-native-color-thief"
+  s.license      = "MIT"
+  # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
+  s.author       = { "author" => "author@domain.cn" }
+  s.platform     = :ios, "10.0"
+  s.source       = { :git => "https://github.com/joinlane/react-native-color-thief.git", :tag => "#{s.version}" }
+
+  s.source_files = "ios/*.swift", "ios/*.h", , "ios/*.m"
+  s.requires_arc = true
+
+  s.dependency 'React'
+end
+

--- a/ios/RNColorThief.podspec
+++ b/ios/RNColorThief.podspec
@@ -1,6 +1,6 @@
 require "json"
 
-package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+package = JSON.parse(File.read(File.join(__dir__, "../package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "RNColorThief"

--- a/ios/RNColorThief.podspec
+++ b/ios/RNColorThief.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "10.0"
   s.source       = { :git => "https://github.com/joinlane/react-native-color-thief.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/*.swift", "ios/*.h", , "ios/*.m"
+  s.source_files = "ios/*.swift", "ios/*.h", "ios/*.m"
   s.requires_arc = true
 
   s.dependency 'React'

--- a/ios/RNColorThief.swift
+++ b/ios/RNColorThief.swift
@@ -1,14 +1,14 @@
 /*
  RNColorThief.swift
  RNColorThiefSwift
- 
+
  Created by Brian DeWeese on 07/29/2019
  Copyright © 2019 Likewise, Inc
- 
+
  License
  -------
  MIT License
- 
+
  Thanks
  ------
  Kazuki Ohara - for ColorThiefSwift
@@ -27,13 +27,13 @@ import Foundation
 public class RNColorThief : NSObject {
 
     public static let defaultColorCount = 5
-    
+
     /**
      ========================
      Public Methods
      ========================
      */
-    
+
     /**
     Use the median cut algorithm to cluster similar colors and return the
      base color from the largest cluster.
@@ -46,23 +46,23 @@ public class RNColorThief : NSObject {
         - ignoreWhite: if true, white pixels are ignored
     - Returns: Promise: resolves dominant rgba color string
      */
-    
+
     @objc
     public func getColor(_ source: String, quality: Int = ColorThief.defaultQuality, ignoreWhite: Bool = ColorThief.defaultIgnoreWhite, width: Int = 0, height: Int = 0, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        guard let image = RNColorThief.getUIImage(from: source) else {
+        guard let image = RNColorThief.getUIImage(from: source, width: width, height: height) else {
             return reject("Error getting image", nil, nil);
         }
-        
+
         guard let dominantColor = ColorThief.getColor(from: image, quality: quality, ignoreWhite: ignoreWhite) else {
              return reject("Error getting dominantColor", nil, nil)
         }
-       
+
         let colorDict = RNColorThief.getRGBDict(from: dominantColor);
         //print(colorString)
-        
+
         resolve(colorDict);
     }
-    
+
 
     /**
      Use the median cut algorithm to cluster similar colors.
@@ -80,78 +80,78 @@ public class RNColorThief : NSObject {
     */
     @objc
     func getPalette(_ source:String, colorCount: Int = defaultColorCount, quality: Int = ColorThief.defaultQuality, ignoreWhite: Bool = ColorThief.defaultIgnoreWhite, width: Int = 0, height: Int = 0, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
-        
-        guard let image = RNColorThief.getUIImage(from: source) else {
+
+        guard let image = RNColorThief.getUIImage(from: source, width: width, height: height) else {
             return reject("Error getting image", nil, nil);
         }
-        
+
         guard let palette = ColorThief.getPalette(from: image, colorCount: colorCount, quality: quality, ignoreWhite: ignoreWhite) else {
             return reject("Error getting palette", nil, nil);
         }
-        
+
         resolve(palette.map{RNColorThief.getRGBDict(from: $0)})
     }
-    
+
     /**
      ========================
      Private Methods
      ========================
      */
     static private func getUIImage(from path:String, width:Int, height: Int) -> UIImage? {
-        let image:UIImage = nil;
-        let _width: Int;
-        let _height: Int;
+        let image:UIImage;
 
         if (path.starts(with: "data:image")) {
-            let temp = path?.components(separatedBy: ",");
-            let dataDecoded : Data = Data(base64Encoded: temp![1], options: .ignoreUnknownCharacters)!;
-            image = UIImage(data: dataDecoded);
+            let temp = path.components(separatedBy: ",");
+            let dataDecoded : Data = Data(base64Encoded: temp[1], options: .ignoreUnknownCharacters)!;
+            image = UIImage(data: dataDecoded)!;
         } else {
             guard let imageURL = NSURL.init(string:path) else {
                 return nil;
             }
-            
+
             guard let imageData = NSData.init(contentsOf: imageURL as URL) else {
                 return nil;
             }
-            
-            guard image = UIImage.init(data: imageData as Data) else {
-                return nil;
-            }
+
+            image = UIImage.init(data: imageData as Data)!;
         }
-        
+
         if (width == 0 && height == 0) {
             return image;
         }
-        
+
         let cgImage = image.cgImage!;
-        
+        let _width: Int;
+        let _height: Int;
+
         if (width == 0) {
-            width = cgImage.width;
+            _width = cgImage.width;
+        } else {
+            _width = width;
         }
-        
+
         if (height == 0) {
-            height = cgImage.height;
+            _height = cgImage.height;
+        } else {
+            _height = height;
         }
-        
+
         let croppedCGImage = cgImage.cropping(to:
-            CGRect(origin: <#T##CGPoint#>(x: 0, y: 0),
-                   size: <#T##CGSize#>(height: height, width: width )
-            )
+            CGRect(x: 0, y: 0, width: _width, height: _height)
         );
-        
+
         return UIImage(cgImage: croppedCGImage!)
     }
-    
+
     static private func getRGBA(from color: MMCQ.Color) -> String {
         return "rgba(\(color.r),\(color.g),\(color.b),1.0)"
     }
-    
+
     static private func getRGBDict(from color: MMCQ.Color) -> Dictionary<String,UInt8> {
         return ["r": color.r, "g": color.g, "b": color.b];
     }
-    
-    
+
+
     /**
      ========================
      React Native

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "react-native-color-thief",
-  "version": "0.1.0",
-  "lockfileVersion": 1
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-color-thief",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "color thief for react-native (ios & android)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-color-thief",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "description": "color thief for react-native (ios & android)",
   "main": "index.js",
   "scripts": {
@@ -30,6 +30,9 @@
     },
     {
       "name": "Jimin Cutrell"
+    },
+    {
+      "name": "Clinton Robinson"
     }
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-color-thief",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "color thief for react-native (ios & android)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-color-thief",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "color thief for react-native (ios & android)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@briandeweese Hey not sure if you want these changes as well, we added the ability to supply optional crop information to only get color info for a specific area on the image. May not be a useful feature if you want to keep RNColorThief "pure" and expect that someone would pass in an already cropped image.  We did this because we wanted to keep the cropping and color thiefing all done in one step on the native side.

Also adding a podspec file.